### PR TITLE
Use factory instead of shared Schema instance which will be modified

### DIFF
--- a/src/MicroElements.Swashbuckle.NodaTime/Schemas.cs
+++ b/src/MicroElements.Swashbuckle.NodaTime/Schemas.cs
@@ -1,4 +1,5 @@
-﻿using Swashbuckle.AspNetCore.Swagger;
+﻿using System;
+using Swashbuckle.AspNetCore.Swagger;
 
 namespace MicroElements.Swashbuckle.NodaTime
 {
@@ -7,28 +8,28 @@ namespace MicroElements.Swashbuckle.NodaTime
     /// </summary>
     public class Schemas
     {
-        public Schema Instant { get; set; }
+        public Func<Schema> Instant { get; set; }
 
-        public Schema LocalDate{ get; set; }
+        public Func<Schema> LocalDate { get; set; }
 
-        public Schema LocalTime { get; set; }
+        public Func<Schema> LocalTime { get; set; }
 
-        public Schema LocalDateTime { get; set; }
+        public Func<Schema> LocalDateTime { get; set; }
 
-        public Schema OffsetDateTime { get; set; }
+        public Func<Schema> OffsetDateTime { get; set; }
 
-        public Schema ZonedDateTime { get; set; }
+        public Func<Schema> ZonedDateTime { get; set; }
 
-        public Schema Interval { get; set; }
+        public Func<Schema> Interval { get; set; }
 
-        public Schema DateInterval { get; set; }
+        public Func<Schema> DateInterval { get; set; }
 
-        public Schema Offset { get; set; }
+        public Func<Schema> Offset { get; set; }
 
-        public Schema Period { get; set; }
+        public Func<Schema> Period { get; set; }
 
-        public Schema Duration { get; set; }
+        public Func<Schema> Duration { get; set; }
 
-        public Schema DateTimeZone { get; set; }
+        public Func<Schema> DateTimeZone { get; set; }
     }
 }

--- a/src/MicroElements.Swashbuckle.NodaTime/SchemasFactory.cs
+++ b/src/MicroElements.Swashbuckle.NodaTime/SchemasFactory.cs
@@ -48,13 +48,13 @@ namespace MicroElements.Swashbuckle.NodaTime
             // https://xml2rfc.tools.ietf.org/public/rfc/html/rfc3339.html#anchor14
             return new Schemas
             {
-                Instant = StringSchema(instant, "date-time"),
-                LocalDate = StringSchema(zonedDateTime.Date, "full-date"),
-                LocalTime = StringSchema(zonedDateTime.TimeOfDay, "partial-time"),
-                LocalDateTime = StringSchema(zonedDateTime.LocalDateTime),
-                OffsetDateTime = StringSchema(instant.WithOffset(zonedDateTime.Offset), "date-time"),
-                ZonedDateTime = StringSchema(zonedDateTime),
-                Interval = new Schema
+                Instant = () => StringSchema(instant, "date-time"),
+                LocalDate = () => StringSchema(zonedDateTime.Date, "full-date"),
+                LocalTime = () => StringSchema(zonedDateTime.TimeOfDay, "partial-time"),
+                LocalDateTime = () => StringSchema(zonedDateTime.LocalDateTime),
+                OffsetDateTime = () => StringSchema(instant.WithOffset(zonedDateTime.Offset), "date-time"),
+                ZonedDateTime = () => StringSchema(zonedDateTime),
+                Interval = () => new Schema
                 {
                     Type = "object",
                     Properties = new Dictionary<string, Schema>
@@ -63,7 +63,7 @@ namespace MicroElements.Swashbuckle.NodaTime
                         { ResolvePropertyName(_serializerSettings, nameof(Interval.End)), StringSchema(interval.End, "date-time") },
                     },
                 },
-                DateInterval = new Schema
+                DateInterval = () => new Schema
                 {
                     Type = "object",
                     Properties = new Dictionary<string, Schema>
@@ -72,10 +72,10 @@ namespace MicroElements.Swashbuckle.NodaTime
                         { ResolvePropertyName(_serializerSettings, nameof(DateInterval.End)), StringSchema(dateInterval.End, "full-date") },
                     },
                 },
-                Offset = StringSchema(zonedDateTime.Offset, "time-numoffset"),
-                Period = StringSchema(period),
-                Duration = StringSchema(interval.Duration),
-                DateTimeZone = StringSchema(dateTimeZone),
+                Offset = () => StringSchema(zonedDateTime.Offset, "time-numoffset"),
+                Period = () => StringSchema(period),
+                Duration = () => StringSchema(interval.Duration),
+                DateTimeZone = () => StringSchema(dateTimeZone),
             };
         }
 

--- a/src/MicroElements.Swashbuckle.NodaTime/SwaggerGenOptionsExtensions.cs
+++ b/src/MicroElements.Swashbuckle.NodaTime/SwaggerGenOptionsExtensions.cs
@@ -46,28 +46,28 @@ namespace MicroElements.Swashbuckle.NodaTime
                 serializerSettings.ConfigureForNodaTime(DateTimeZoneProviders.Tzdb);
 
             Schemas schemas = new SchemasFactory(serializerSettings).CreateSchemas();
-            config.MapType<Instant>        (() => schemas.Instant);
-            config.MapType<LocalDate>      (() => schemas.LocalDate);
-            config.MapType<LocalTime>      (() => schemas.LocalTime);
-            config.MapType<LocalDateTime>  (() => schemas.LocalDateTime);
-            config.MapType<OffsetDateTime> (() => schemas.OffsetDateTime);
-            config.MapType<ZonedDateTime>  (() => schemas.ZonedDateTime);
-            config.MapType<Interval>       (() => schemas.Interval);
-            config.MapType<DateInterval>   (() => schemas.DateInterval);
-            config.MapType<Offset>         (() => schemas.Offset);
-            config.MapType<Period>         (() => schemas.Period);
-            config.MapType<Duration>       (() => schemas.Duration);
-            config.MapType<DateTimeZone>   (() => schemas.DateTimeZone);
+            config.MapType<Instant>        (schemas.Instant);
+            config.MapType<LocalDate>      (schemas.LocalDate);
+            config.MapType<LocalTime>      (schemas.LocalTime);
+            config.MapType<LocalDateTime>  (schemas.LocalDateTime);
+            config.MapType<OffsetDateTime> (schemas.OffsetDateTime);
+            config.MapType<ZonedDateTime>  (schemas.ZonedDateTime);
+            config.MapType<Interval>       (schemas.Interval);
+            config.MapType<DateInterval>   (schemas.DateInterval);
+            config.MapType<Offset>         (schemas.Offset);
+            config.MapType<Period>         (schemas.Period);
+            config.MapType<Duration>       (schemas.Duration);
+            config.MapType<DateTimeZone>   (schemas.DateTimeZone);
 
-            config.MapType<Instant?>       (() => schemas.Instant);
-            config.MapType<LocalDate?>     (() => schemas.LocalDate);
-            config.MapType<LocalTime?>     (() => schemas.LocalTime);
-            config.MapType<LocalDateTime?> (() => schemas.LocalDateTime);
-            config.MapType<OffsetDateTime?>(() => schemas.OffsetDateTime);
-            config.MapType<ZonedDateTime?> (() => schemas.ZonedDateTime);
-            config.MapType<Interval?>      (() => schemas.Interval);
-            config.MapType<Offset?>        (() => schemas.Offset);
-            config.MapType<Duration?>      (() => schemas.Duration);
+            config.MapType<Instant?>       (schemas.Instant);
+            config.MapType<LocalDate?>     (schemas.LocalDate);
+            config.MapType<LocalTime?>     (schemas.LocalTime);
+            config.MapType<LocalDateTime?> (schemas.LocalDateTime);
+            config.MapType<OffsetDateTime?>(schemas.OffsetDateTime);
+            config.MapType<ZonedDateTime?> (schemas.ZonedDateTime);
+            config.MapType<Interval?>      (schemas.Interval);
+            config.MapType<Offset?>        (schemas.Offset);
+            config.MapType<Duration?>      (schemas.Duration);
         }
     }
 }


### PR DESCRIPTION
The shared instance of Schema can be modified outside [like this](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/blob/master/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/SchemaRegistry.cs#L251), other places will be affected and hence bugs.