### PR TITLE
Update Swashbuckle dependencies to 10.0.0

### DIFF
--- a/samples/WebApiSample/Startup.cs
+++ b/samples/WebApiSample/Startup.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using NodaTime;

--- a/samples/WebApiSample/WebApiSample.csproj
+++ b/samples/WebApiSample/WebApiSample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -9,7 +9,8 @@
 
     <PackageReference Include="NodaTime" Version="3.0.3" />
     <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MicroElements.Swashbuckle.NodaTime/MicroElements.Swashbuckle.NodaTime.csproj
+++ b/src/MicroElements.Swashbuckle.NodaTime/MicroElements.Swashbuckle.NodaTime.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\common.props" />
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
@@ -10,8 +10,12 @@
   <ItemGroup>
     <PackageReference Include="NodaTime" Version="3.0.0" />
     <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.0.0" />
-    <PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.5.1" />
+    <PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.1.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    
   </ItemGroup>
 
 </Project>

--- a/src/MicroElements.Swashbuckle.NodaTime/NamingPolicyParameterFilter.cs
+++ b/src/MicroElements.Swashbuckle.NodaTime/NamingPolicyParameterFilter.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) MicroElements. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace MicroElements.Swashbuckle.NodaTime
@@ -23,9 +23,10 @@ namespace MicroElements.Swashbuckle.NodaTime
         }
 
         /// <inheritdoc />
-        public void Apply(OpenApiParameter parameter, ParameterFilterContext context)
+        public void Apply(IOpenApiParameter parameter, ParameterFilterContext context)
         {
-            parameter.Name = _nodaTimeSchemaSettings.ResolvePropertyName(parameter.Name);
+            if (parameter is OpenApiParameter openApiParameter)
+                openApiParameter.Name = _nodaTimeSchemaSettings.ResolvePropertyName(parameter.Name);
         }
     }
 }

--- a/src/MicroElements.Swashbuckle.NodaTime/NodaTimeSchemaSettingsFactory.cs
+++ b/src/MicroElements.Swashbuckle.NodaTime/NodaTimeSchemaSettingsFactory.cs
@@ -30,8 +30,6 @@ namespace MicroElements.Swashbuckle.NodaTime
             string FormatToJson(object value)
             {
                 string formatToJson = JsonConvert.SerializeObject(value, serializerSettings);
-                if (formatToJson.StartsWith("\"") && formatToJson.EndsWith("\""))
-                    formatToJson = formatToJson.Substring(1, formatToJson.Length - 2);
                 return formatToJson;
             }
 
@@ -64,15 +62,7 @@ namespace MicroElements.Swashbuckle.NodaTime
         {
             string FormatToJson(object value)
             {
-                if (value is DateTimeZone dateTimeZone)
-                {
-                    // TODO: remove after PR released: https://github.com/nodatime/nodatime.serialization/pull/57
-                    return dateTimeZone.Id;
-                }
-
                 string formatToJson = System.Text.Json.JsonSerializer.Serialize(value, jsonSerializerOptions);
-                if (formatToJson.StartsWith("\"") && formatToJson.EndsWith("\""))
-                    formatToJson = formatToJson.Substring(1, formatToJson.Length - 2);
                 return formatToJson;
             }
 

--- a/src/MicroElements.Swashbuckle.NodaTime/Schemas.cs
+++ b/src/MicroElements.Swashbuckle.NodaTime/Schemas.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 
 namespace MicroElements.Swashbuckle.NodaTime
 {

--- a/src/MicroElements.Swashbuckle.NodaTime/SchemasFactory.cs
+++ b/src/MicroElements.Swashbuckle.NodaTime/SchemasFactory.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using Microsoft.OpenApi.Any;
-using Microsoft.OpenApi.Models;
+using System.Text.Json.Nodes;
+using Microsoft.OpenApi;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using NodaTime;
@@ -45,8 +45,8 @@ namespace MicroElements.Swashbuckle.NodaTime
                 ZonedDateTime = () => StringSchema(examples.ZonedDateTime),
                 Interval = () => new OpenApiSchema
                 {
-                    Type = "object",
-                    Properties = new Dictionary<string, OpenApiSchema>
+                    Type = JsonSchemaType.Object,
+                    Properties = new Dictionary<string, IOpenApiSchema>
                     {
                         { ResolvePropertyName(nameof(Interval.Start)), StringSchema(examples.Interval.Start, "date-time") },
                         { ResolvePropertyName(nameof(Interval.End)), StringSchema(examples.Interval.End, "date-time") },
@@ -54,8 +54,8 @@ namespace MicroElements.Swashbuckle.NodaTime
                 },
                 DateInterval = () => new OpenApiSchema
                 {
-                    Type = "object",
-                    Properties = new Dictionary<string, OpenApiSchema>
+                    Type = JsonSchemaType.Object,
+                    Properties = new Dictionary<string, IOpenApiSchema>
                     {
                         { ResolvePropertyName(nameof(DateInterval.Start)), StringSchema(examples.DateInterval.Start, "date") },
                         { ResolvePropertyName(nameof(DateInterval.End)), StringSchema(examples.DateInterval.End, "date") },
@@ -74,9 +74,9 @@ namespace MicroElements.Swashbuckle.NodaTime
         {
             return new OpenApiSchema
             {
-                Type = "string",
+                Type = JsonSchemaType.String,
                 Example = _settings.ShouldGenerateExamples
-                    ? new OpenApiString(FormatToJson(exampleObject))
+                    ? JsonNode.Parse(FormatToJson(exampleObject))
                     : null,
                 Format = format
             };

--- a/test/MicroElements.Swashbuckle.NodaTime.Tests/MicroElements.Swashbuckle.NodaTime.Tests.csproj
+++ b/test/MicroElements.Swashbuckle.NodaTime.Tests/MicroElements.Swashbuckle.NodaTime.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/MicroElements.Swashbuckle.NodaTime.Tests/SchemasTests.cs
+++ b/test/MicroElements.Swashbuckle.NodaTime.Tests/SchemasTests.cs
@@ -1,8 +1,9 @@
 using System;
 using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using FluentAssertions;
-using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi;
 using Newtonsoft.Json;
 using NodaTime;
 using NodaTime.Serialization.JsonNet;
@@ -46,59 +47,59 @@ namespace MicroElements.Swashbuckle.NodaTime.Tests
         {
             Schemas schemas = new SchemasFactory(nodaTimeSchemaSettings).CreateSchemas();
 
-            schemas.Instant().Type.Should().Be("string");
+            schemas.Instant().Type.Should().Be(JsonSchemaType.String);
             schemas.Instant().Format.Should().Be("date-time");
             schemas.Instant().Example.AsString().Should().Be("2020-05-23T10:30:50Z");
 
-            schemas.LocalDate().Type.Should().Be("string");
+            schemas.LocalDate().Type.Should().Be(JsonSchemaType.String);
             schemas.LocalDate().Format.Should().Be("date");
             schemas.LocalDate().Example.AsString().Should().Be("2020-05-23");
 
-            schemas.LocalTime().Type.Should().Be("string");
+            schemas.LocalTime().Type.Should().Be(JsonSchemaType.String);
             schemas.LocalTime().Format.Should().Be(null);
             schemas.LocalTime().Example.AsString().Should().Be("13:30:50");
 
-            schemas.LocalDateTime().Type.Should().Be("string");
+            schemas.LocalDateTime().Type.Should().Be(JsonSchemaType.String);
             schemas.LocalDateTime().Format.Should().Be(null);
             schemas.LocalDateTime().Example.AsString().Should().Be("2020-05-23T13:30:50");
 
-            schemas.OffsetDateTime().Type.Should().Be("string");
+            schemas.OffsetDateTime().Type.Should().Be(JsonSchemaType.String);
             schemas.OffsetDateTime().Format.Should().Be("date-time");
             schemas.OffsetDateTime().Example.AsString().Should().Be("2020-05-23T13:30:50+03:00");
 
-            schemas.ZonedDateTime().Type.Should().Be("string");
+            schemas.ZonedDateTime().Type.Should().Be(JsonSchemaType.String);
             schemas.ZonedDateTime().Format.Should().Be(null);
             schemas.ZonedDateTime().Example.AsString().Should().Be("2020-05-23T13:30:50+03 Europe/Moscow");
 
-            schemas.Interval().Type.Should().Be("object");
+            schemas.Interval().Type.Should().Be(JsonSchemaType.Object);
             schemas.Interval().Properties["Start"].Example.AsString().Should().Be("2020-05-23T10:30:50Z");
             schemas.Interval().Properties["End"].Example.AsString().Should().Be("2020-05-24T11:31:51.001Z");
 
-            schemas.DateInterval().Type.Should().Be("object");
+            schemas.DateInterval().Type.Should().Be(JsonSchemaType.Object);
             schemas.DateInterval().Properties["Start"].Example.AsString().Should().Be("2020-05-23");
             schemas.DateInterval().Properties["End"].Example.AsString().Should().Be("2020-05-24");
 
-            schemas.Offset().Type.Should().Be("string");
+            schemas.Offset().Type.Should().Be(JsonSchemaType.String);
             schemas.Offset().Format.Should().Be(null);
             schemas.Offset().Example.AsString().Should().Be("+03");
 
-            schemas.Period().Type.Should().Be("string");
+            schemas.Period().Type.Should().Be(JsonSchemaType.String);
             schemas.Period().Format.Should().Be(null);
             schemas.Period().Example.AsString().Should().Be("P1DT1H1M1S1s");
 
-            schemas.Duration().Type.Should().Be("string");
+            schemas.Duration().Type.Should().Be(JsonSchemaType.String);
             schemas.Duration().Format.Should().Be(null);
             schemas.Duration().Example.AsString().Should().Be("25:01:01.001");
 
-            schemas.OffsetDate().Type.Should().Be("string");
+            schemas.OffsetDate().Type.Should().Be(JsonSchemaType.String);
             schemas.OffsetDate().Format.Should().Be(null);
             schemas.OffsetDate().Example.AsString().Should().Be("2020-05-23+03");
 
-            schemas.OffsetTime().Type.Should().Be("string");
+            schemas.OffsetTime().Type.Should().Be(JsonSchemaType.String);
             schemas.OffsetTime().Format.Should().Be(null);
             schemas.OffsetTime().Example.AsString().Should().Be("13:30:50+03");
 
-            schemas.DateTimeZone().Type.Should().Be("string");
+            schemas.DateTimeZone().Type.Should().Be(JsonSchemaType.String);
             schemas.DateTimeZone().Format.Should().Be(null);
             schemas.DateTimeZone().Example.AsString().Should().Be("Europe/Moscow");
         }
@@ -106,11 +107,8 @@ namespace MicroElements.Swashbuckle.NodaTime.Tests
 
     internal static class TestExtensions
     {
-        public static string AsString(this IOpenApiAny openApiAny)
+        public static string AsString(this JsonNode openApiAny)
         {
-            if (openApiAny is OpenApiString openApiString)
-                return openApiString.Value;
-
             return openApiAny.ToString();
         }
     }


### PR DESCRIPTION
- Starting from 9.0.0, interface IParameterFilter moved from Swashbuckle.AspNetCore to Swashbuckle.AspNetCore.SwaggerGen. So, without updating dependencies, there are runtime exception "Method not found".
- I updated target framework since Swashbuckle requires .net 8.0+ starting from 9.0.0
- 10.0.0 has many breaking changes: https://github.com/domaindrivendev/Swashbuckle.AspNetCore/blob/master/docs/migrating-to-v10.md
- PR https://github.com/nodatime/nodatime.serialization/pull/57 released in NodaTime.Serialization.SystemTextJson 1.1.0, so i remove TODO

ps thx for amazing lib!